### PR TITLE
invalid file type dropped modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "concats",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "concats",
   "description": "Output a single-column csv file containing rows of concatenated fields from an input csv file. Desktop app built using Electron.js and Vue.js.",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "private": false,
   "author": {
     "name": "Brian Zelip"

--- a/src/components/Form/TheFileSelector.vue
+++ b/src/components/Form/TheFileSelector.vue
@@ -11,7 +11,7 @@
       @mouseleave="isactive = false"
       class="dropzone"
     >
-      <p>click to select a file</p>
+      <p>click to select a csv/tsv file</p>
       <PlusSvg
         :class="{ isactive }"
         class="add"

--- a/src/components/Form/TheFileSelector.vue
+++ b/src/components/Form/TheFileSelector.vue
@@ -26,6 +26,7 @@ const fs = require("fs");
 const { dialog } = require("electron").remote;
 
 import PlusSvg from "../../assets/plus.svg";
+import TheFileSelectorModal from "./TheFileSelectorModal.vue";
 
 export default {
   data() {
@@ -64,7 +65,8 @@ export default {
     }
   },
   components: {
-    PlusSvg
+    PlusSvg,
+    TheFileSelectorModal
   }
 };
 </script>
@@ -73,6 +75,7 @@ export default {
 section {
   display: flex;
   flex-grow: 1;
+  position: relative;
 }
 label {
   margin-right: 1rem;
@@ -88,6 +91,7 @@ label {
   border-width: 4px;
   border-style: dashed;
   border-color: rgba(0, 0, 0, 0.333);
+  border-radius: 4px;
   transition: border-color 0.3s;
 }
 .add {

--- a/src/components/Form/TheFileSelector.vue
+++ b/src/components/Form/TheFileSelector.vue
@@ -18,6 +18,12 @@
       ></PlusSvg>
       <p>or drag and drop a file</p>
     </div>
+    <transition name="fade">
+      <TheFileSelectorModal
+        v-if="showModal"
+        v-on:hide-modal="showModal = false"
+      ></TheFileSelectorModal>
+    </transition>
   </section>
 </template>
 
@@ -31,7 +37,8 @@ import TheFileSelectorModal from "./TheFileSelectorModal.vue";
 export default {
   data() {
     return {
-      isactive: false
+      isactive: false,
+      showModal: false
     };
   },
   methods: {
@@ -57,6 +64,7 @@ export default {
       const re = /(\.[tc]sv)$/gi;
 
       if (fileName.search(re) === -1) {
+        this.showModal = true;
         return;
       }
 
@@ -108,5 +116,13 @@ label {
 .dropzone.isactive {
   border-color: rgba(0, 0, 0, 1);
   transition: border-color 0.3s;
+}
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.5s;
+}
+.fade-enter,
+.fade-leave-to {
+  opacity: 0;
 }
 </style>

--- a/src/components/Form/TheFileSelectorModal.vue
+++ b/src/components/Form/TheFileSelectorModal.vue
@@ -1,0 +1,50 @@
+<template>
+  <aside>
+    <div>
+      <InfoCircleSVG class="icon"></InfoCircleSVG>
+      <span>Please drag and drop a csv/tsv file!</span>
+    </div>
+  </aside>
+</template>
+
+<script>
+import InfoCircleSVG from "../../assets/info-circle.svg";
+
+export default {
+  components: {
+    InfoCircleSVG
+  }
+};
+</script>
+
+
+<style scoped>
+aside {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.111);
+}
+div {
+  display: flex;
+  align-items: center;
+  margin-top: 4rem;
+  padding: 1.5rem 2rem;
+  font-size: 1rem;
+  border: 2px solid #ef5753;
+  border-radius: 2px;
+  background-color: #fcebea;
+  color: #cc1f1a;
+}
+.icon {
+  height: 25px;
+  width: 25px;
+  margin-right: 0.5rem;
+  fill: #cc1f1a;
+}
+</style>

--- a/src/components/Form/TheFileSelectorModal.vue
+++ b/src/components/Form/TheFileSelectorModal.vue
@@ -1,8 +1,11 @@
 <template>
-  <aside>
+  <aside
+    @dragover.prevent
+    @drop.prevent
+  >
     <div>
       <InfoCircleSVG class="icon"></InfoCircleSVG>
-      <span>Please drag and drop a csv/tsv file!</span>
+      <span>Please select a csv/tsv file!</span>
     </div>
   </aside>
 </template>
@@ -13,10 +16,14 @@ import InfoCircleSVG from "../../assets/info-circle.svg";
 export default {
   components: {
     InfoCircleSVG
+  },
+  mounted() {
+    setTimeout(() => {
+      this.$emit("hide-modal");
+    }, 1500);
   }
 };
 </script>
-
 
 <style scoped>
 aside {
@@ -28,7 +35,7 @@ aside {
   display: flex;
   flex-direction: column;
   align-items: center;
-  background: rgba(0, 0, 0, 0.111);
+  background: rgba(0, 0, 0, 0.222);
 }
 div {
   display: flex;


### PR DESCRIPTION
This PR:
- shows temporary modal when a non csv/tsv file is dropped on dropzone
- adds guidance text on what file types are valid to TheFileSelector

closes #19 
closes #27
