### PR TITLE
Progress svg opacity

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -73,3 +73,8 @@ Design the app's user steps so that, instead of scrolling down the page as steps
 - shows temporary modal when invalid file types are dropped onto TheFileSelector dropzone
 - adds helpful text about valid file types to TheFileSelector
 - here's [the !SO answer](https://stackoverflow.com/a/48481398/2145103) that helped me achieve the temporary modal solution by using the mounted() hook in the modal component to implement the `setTimeout()`
+
+## `progress-svg-opacity` feature branch, starting at v1.10.0
+
+- change the opacity transition of the angle arrows in the progress bar to point the user to the next step
+- gets rid of all `.iscomplete` classes in favor of `.iscurrent`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "concats",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "concats",
   "description": "Output a single-column csv file containing rows of concatenated fields from an input csv file. Desktop app built using Electron.js and Vue.js.",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": false,
   "author": {
     "name": "Brian Zelip"

--- a/src/components/TheProgressBar.vue
+++ b/src/components/TheProgressBar.vue
@@ -5,12 +5,12 @@
       class="one"
     >
       <FilePlusSvg
-        :class="{iscomplete: onFileInput }"
+        :class="{iscurrent: onFileInput }"
         class="stage"
       ></FilePlusSvg>
     </div>
     <AngleRightSvg
-      :class="{iscomplete: onHeadersInput }"
+      :class="{iscurrent: onStep1 }"
       class="arrow"
     ></AngleRightSvg>
     <div
@@ -18,12 +18,12 @@
       class="two"
     >
       <TasksSvg
-        :class="{iscomplete: onHeadersInput }"
+        :class="{iscurrent: onHeadersInput }"
         class="stage"
       ></TasksSvg>
     </div>
     <AngleRightSvg
-      :class="{iscomplete: onDownload }"
+      :class="{iscurrent: onStep2 }"
       class="arrow"
     ></AngleRightSvg>
     <div
@@ -31,7 +31,7 @@
       class="three"
     >
       <FileDownloadSvg
-        :class="{iscomplete: onDownload }"
+        :class="{iscurrent: onDownload }"
         class="stage"
       ></FileDownloadSvg>
     </div>
@@ -115,8 +115,8 @@ div.three::after {
   height: 20px;
   margin: 0 1rem;
 }
-.stage.iscomplete,
-.arrow.iscomplete {
+.stage.iscurrent,
+.arrow.iscurrent {
   opacity: 1;
   transition: opacity 1.25s;
 }


### PR DESCRIPTION
This PR:

- updates progress bar svg arrow opacity transitions so that they point the user towards the next step
- closes #29 