### PR TITLE
Progress bar update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "concats",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "concats",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "concats",
   "description": "Output a single-column csv file containing rows of concatenated fields from an input csv file. Desktop app built using Electron.js and Vue.js.",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "private": false,
   "author": {
     "name": "Brian Zelip"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "concats",
   "description": "Output a single-column csv file containing rows of concatenated fields from an input csv file. Desktop app built using Electron.js and Vue.js.",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "private": false,
   "author": {
     "name": "Brian Zelip"

--- a/package.json
+++ b/package.json
@@ -56,5 +56,5 @@
     "last 2 versions",
     "not ie <= 8"
   ],
-  "main": "src/main/background.js"
+  "main": "background.js"
 }

--- a/src/renderer/components/TheProgressBar.vue
+++ b/src/renderer/components/TheProgressBar.vue
@@ -95,7 +95,7 @@ div::after {
   width: 35px;
   font-size: 0.75rem;
   text-align: center;
-  opacity: 0;
+  opacity: 0.333;
 }
 div.iscurrent::after {
   opacity: 1;


### PR DESCRIPTION
This PR:

- shows ProgressBar step numbers grayed out by default, and shows the current step number as bold
- also fixes build error by reinstating `main: "background.js"` in package.json (it turns out this value shouldn't be relative to the source code, but relative to the final dist_electron build)
- closes #38 